### PR TITLE
Swagger implementation updates

### DIFF
--- a/swaggerapi/Controllers/ValuesController.cs
+++ b/swaggerapi/Controllers/ValuesController.cs
@@ -1,9 +1,9 @@
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Swashbuckle.SwaggerGen.Annotations;
 
 [Route("values")]
+[Produces("application/json")]
 public class ValuesController : Controller
 {
     private readonly IRepository _repository;
@@ -11,27 +11,51 @@ public class ValuesController : Controller
         _repository = repository;
     }
 
+    /// <summary>
+    /// Returns a collection of MyModel items
+    /// </summary>
+    /// <param name="[Produces("application/json""></param>
+    /// <param name="[ProducesResponseType(typeof(IEnumerable<MyModel>)"></param>
+    /// <param name="GetAll("></param>
+    /// <returns></returns>
+    /// <response code="200">Returns a collection of MyModel items</response>
     [Authorize]
     [HttpGet("")]
-    [Produces(typeof(IEnumerable<MyModel>))]
-    [SwaggerResponse(System.Net.HttpStatusCode.OK, Type = typeof(IEnumerable<MyModel>))]
+    [Produces("application/json", Type = typeof(IEnumerable<MyModel>))]
+    [ProducesResponseType(typeof(IEnumerable<MyModel>), 200)]
     public IActionResult GetAll()
     {
         return new ObjectResult(_repository.GetAll());
     } 
 
+    /// <summary>
+    /// Returns a specific MyModel item 
+    /// </summary>
+    /// <param name="id"></param>
+    /// <returns></returns>
+    /// <response code="200">Returns specific MyModel item</response> <summary>
+    /// <response code="404">If the MyModel item is null</response>
     [HttpGet("{id}", Name = "GetModel")]
     [Produces(typeof(MyModel))]
-    [SwaggerResponse(System.Net.HttpStatusCode.OK, Type = typeof(MyModel))]
+    [ProducesResponseType(typeof(MyModel), 200)]
+    [ProducesResponseType(typeof(MyModel), 404)]
     public IActionResult  Get(string id)
     {
         return new ObjectResult(_repository.Get(id));
     } 
 
+    /// <summary>
+    /// Creates a MyModel item
+    /// </summary>
+    /// <param name="item"></param>
+    /// <returns>new created MyModel item</returns>
+    /// <response code="201">Returns the newly created item</response>
+    /// <response code="400">If the item is null</response>
     [Authorize]
     [HttpPost]
     [Produces(typeof(MyModel))]
-    [SwaggerResponse(System.Net.HttpStatusCode.OK, Type = typeof(MyModel))]
+    [ProducesResponseType(typeof(MyModel), 201)]
+    [ProducesResponseType(typeof(MyModel), 400)]
     public IActionResult Create([FromBody] MyModel item)
     {
         if (item == null)
@@ -42,16 +66,30 @@ public class ValuesController : Controller
         return CreatedAtRoute("GetModel", new { id = item.Id }, item);
     }
 
+    /// <summary>
+    /// Updates a specific MyModel item
+    /// </summary>
+    /// <param name="id"></param>
+    /// <returns></returns>
+    /// <response code="204">Returns when item was updated</response>
     [Authorize]
-    [HttpPut("{id}")]    
+    [HttpPut("{id}")]
+    [ProducesResponseType(typeof(MyModel), 204)]
     public IActionResult Update(string id, [FromBody] MyModel item)
     {
         _repository.Edit(id, item);
         return NoContent();
     } 
 
+    /// <summary>
+    /// Updates a specific MyModel item
+    /// </summary>
+    /// <param name="id"></param>
+    /// <returns></returns> <summary>
+    /// <response code="204">Returns when item was updated</response>
     [Authorize]
     [HttpDelete("{id}")]
+    [ProducesResponseType(typeof(MyModel), 204)]
     public IActionResult Delete(string id)
     {
         _repository.Delete(id);

--- a/swaggerapi/Startup.cs
+++ b/swaggerapi/Startup.cs
@@ -1,13 +1,11 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.PlatformAbstractions;
 using Swashbuckle.Swagger.Model;
+using System.IO;
 
 namespace swaggerapi
 {
@@ -37,6 +35,9 @@ namespace swaggerapi
                     Description="API Sample made for Auth0",
                     TermsOfService = "None"
                 });
+                var basePath = PlatformServices.Default.Application.ApplicationBasePath;
+                var fullPath = Path.Combine(basePath, "swaggerapi.xml");
+                options.IncludeXmlComments(fullPath);
             });
         }
 

--- a/swaggerapi/project.json
+++ b/swaggerapi/project.json
@@ -12,7 +12,7 @@
     "Microsoft.Extensions.Configuration.Json": "1.0.0",
     "Microsoft.Extensions.Configuration.CommandLine": "1.0.0",
     "Microsoft.Extensions.Options.ConfigurationExtensions": "1.0.0",
-    "Swashbuckle": "6.0.0-beta901",
+    "Swashbuckle": "6.0.0-beta902",
     "Microsoft.AspNetCore.Authentication.JwtBearer": "1.0.0"    
   },
 
@@ -31,7 +31,8 @@
 
   "buildOptions": {
     "emitEntryPoint": true,
-    "preserveCompilationContext": true
+    "preserveCompilationContext": true,
+    "xmlDoc": true
   },
 
   "runtimeOptions": {


### PR DESCRIPTION
This commit updates Swagger Dotnet Core Swashbuckle version
to recent release to be in sync with current docs.asp.net:
https://docs.asp.net/en/latest/tutorials/web-api-help-pages-using-swagger.html

The changes include
- NuGet version bump
- implementation changes in attributes
- adding documentation comments and proper
  attributes
- project configuration to use and generated xml docs
- Swagger (Swashbuckle) fixes

I have problem in getting xml included in Swagger UI
opposed to docs.asp.net info - but maybe this is only
my machine problem (OS X)

The changes should not change original article users experience.
Thanks!
