### PR TITLE
Update VSCode task for x-platform execution

### DIFF
--- a/swaggerapi/.vscode/tasks.json
+++ b/swaggerapi/.vscode/tasks.json
@@ -12,5 +12,25 @@
             "isBuildCommand": true,
             "problemMatcher": "$msCompile"
         }
-    ]
+    ],
+    "linux": {
+        "tasks": [
+            {
+                "taskName": "build",
+                "args": [
+                    "${workspaceRoot}/project.json"
+                ]
+            }
+        ]
+    },
+    "osx": {
+        "tasks": [
+            {
+                "taskName": "build",
+                "args": [
+                    "${workspaceRoot}//project.json"
+                ]
+            }
+        ]
+    }
 }


### PR DESCRIPTION
The platform specific properties to override project
path literals. See:
https://code.visualstudio.com/docs/editor/tasks\#_operating-system-specific-properties

This allows to execute VSCode tasks on OS X (and hopefully on Linux)

Thanks!
