### PR TITLE
Fix web application start url references

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ In the [Web App appsettings.json](./swaggerweb/appsettings.json), you need to fi
         "Domain": "{YOUR_AUTH0_DOMAIN}",
         "ClientId": "{YOUR_AUTH0_CLIENTID}",
         "ClientSecret": "{YOUR_AUTH0_CLIENTSECRET}",
-        "CallbackUrl": "http://localhost:5000/signin-auth0"
+        "CallbackUrl": "http://localhost:5001/signin-auth0"
       } 
     }
 

--- a/swaggerweb/Properties/launchSettings.json
+++ b/swaggerweb/Properties/launchSettings.json
@@ -3,7 +3,7 @@
     "swaggerweb": {
       "commandName": "Project",
       "launchBrowser": true,
-      "launchUrl": "http://localhost:5000",
+      "launchUrl": "http://localhost:5001",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/swaggerweb/Startup.cs
+++ b/swaggerweb/Startup.cs
@@ -66,7 +66,7 @@ namespace swaggerweb
                 // Set response type to code
                 ResponseType = "code",
 
-                // Set the callback path, so Auth0 will call back to http://localhost:5000/signin-auth0 
+                // Set the callback path, so Auth0 will call back to http://localhost:5001/signin-auth0
                 // Also ensure that you have added the URL as an Allowed Callback URL in your Auth0 dashboard 
                 CallbackPath = new PathString("/signin-auth0"),
 

--- a/swaggerweb/appsettings.json
+++ b/swaggerweb/appsettings.json
@@ -3,6 +3,6 @@
     "Domain": "{DOMAIN}",
     "ClientId": "{CLIENT_ID}",
     "ClientSecret": "{CLIENT_SECRET}",
-    "CallbackUrl": "http://localhost:5000/signin-auth0"
+    "CallbackUrl": "http://localhost:5001/signin-auth0"
   } 
 }


### PR DESCRIPTION
The web api uses :5000 port, so the web application
has to use other port, here 5001 as in server urls

This works now on OS X, so I assume should work x-plat.

![image](https://cloud.githubusercontent.com/assets/14539/18326463/2552e414-7546-11e6-9daa-941e723577fa.png)

Thanks!
